### PR TITLE
add CitaClient.call_mode

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -388,6 +388,16 @@
     200
 
 
+设置调用模式
+~~~~~~~~~~~~~~~
+
+在调用合约的只读方法时, 默认会使用已共识的区块信息, 即 ``latest`` . 但也可以设置为使用刚出块还未共识的区块信息, 即 ``pending`` . 这个模式适合于只有一个CITA节点或单元测试. 可以通过 :meth:`~cita.CitaClient.set_call_mode` 进行设置. 设置后会影响由此实例发起的之后所有的调用.
+
+    >>> from cita import CitaClient, ContractClass
+    >>> client = CitaClient('http://127.0.0.1:1337')
+    >>> client.set_call_mode('pending')
+
+
 使用ContractClass
 -----------------------------
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -134,14 +134,14 @@ def test_client():
     r = client.call_readonly_func(contract_addr, simple_obj.get.address, from_addr=user_addr)
     assert decode_param('uint', r) == value
     assert simple_obj.get() == value  # 因为交易还未被确认.
-    simple_obj.set_call_mode('pending')
+    client.set_call_mode('pending')
     assert simple_obj.get() == new_value  # 读取未确认的数据.
 
     client.confirm_transaction(tx_hash)
 
     # 读取状态
     assert simple_obj.get() == new_value
-    simple_obj.set_call_mode('latest')
+    client.set_call_mode('latest')
     assert simple_obj.get() == new_value  # 交易已确认.
 
 


### PR DESCRIPTION
可以设置call方法使用的是latest还是pending的区块.
一旦设置, 则会影响绑定了这个CitaClient实例的所有ContractClass  ContractProxy实例的后续调用.

pending模式非常适合于单CITA节点的应用, 或者集成测试. 效果就是不用等待交易确认了.